### PR TITLE
fix: UIS-396 remove filterBy label when there is only a searchbox

### DIFF
--- a/components/GridToolBox/index.js
+++ b/components/GridToolBox/index.js
@@ -278,10 +278,16 @@ class GridToolBox extends Component {
         let labelClass = this.haveSelectedOrChecked() ? style.link : '';
         let toggle = () => this.haveSelectedOrChecked() && this.setState({showFilters: false});
         let filtersNumber = 0;
+        let leftSide;
+        if (this.props.filterElements.length === 1 && this.props.filterElements[0]['type'] === filterElementTypes.searchBox) {
+            leftSide = this.haveSelectedOrChecked() ? <span className={style.link}>Show buttons</span> : '';
+        } else {
+            leftSide = this.haveSelectedOrChecked() ? <span className={style.link}>Show buttons</span> : 'Filter by';
+        }
         return (
             <div className={style.toolbarWrap}>
                 <div className={classnames(style.toolbarElement, style.label, labelClass)} onClick={toggle}>
-                    {this.haveSelectedOrChecked() ? <span className={style.link}>Show buttons</span> : 'Filter by'}
+                    {leftSide}
                 </div>
 
                 <div className={style.pullRight}>


### PR DESCRIPTION
In GridToolBox component when there is only a search field available to user there is no need for filter by label on the left. Instead this label is needed when there are several options for filtering available