### PR TITLE
fix: searchbox styling

### DIFF
--- a/components/SearchBox/style.css
+++ b/components/SearchBox/style.css
@@ -32,8 +32,6 @@
 .searchBoxWrap .label {
     display: inline-block;
     width: 30%;
-    margin: 5px 4% 0 0;
-    margin-right: 0px;
     font-size: 14px;
     color: #595959;
 }

--- a/components/SearchBox/style.css
+++ b/components/SearchBox/style.css
@@ -34,6 +34,8 @@
     width: 30%;
     margin: 5px 4% 0 0;
     margin-right: 0px;
+    font-size: 14px;
+    color: #595959;
 }
 
 .searchBoxWrap button {


### PR DESCRIPTION
this is needed to make searchbox label styles like the labels in other components. for example input or dropdown