### PR TITLE
fix: preload window to be on top of all windows except error window

### DIFF
--- a/components/Preloader/index.js
+++ b/components/Preloader/index.js
@@ -3,7 +3,7 @@ import Dialog from 'material-ui/Dialog/Dialog';
 
 const Preloader = ({open = true, message}) => {
     return (
-      <Dialog open={open} title='Loading, please wait'>
+      <Dialog open={open} title='Loading, please wait' style={{zIndex: 9998}}>
         {message}
       </Dialog>
     );


### PR DESCRIPTION
set z-index of preload window to be ot top of other windows except error.
ErrorWindow has z-index = 9999. PreloadWindow has z-index = 9998