### PR TITLE
fix: logout redirect

### DIFF
--- a/containers/Gate/index.js
+++ b/containers/Gate/index.js
@@ -35,6 +35,7 @@ class Gate extends Component {
         // if cookieCheck has passed and the user is authenticated, redirect to LoginPage
         // if the user is authenticated and there is a result from identity.check, load the gate (set permissions and fetch translations)
         // if the session expires, redirect to LoginPage
+
         if (!cookieChecked && nextProps.cookieChecked && !nextProps.authenticated) {
             this.context.router.push('/login');
         } else if (nextProps.authenticated && !result && nextProps.result) {
@@ -43,6 +44,8 @@ class Gate extends Component {
             this.context.router.push('/login');
         } else if (!forceLogOut && nextProps.forceLogOut) {
             logout();
+        } else if (!nextProps.authenticated) {
+            this.context.router.push('/login');
         }
     }
 

--- a/containers/LoginForm/reducer.js
+++ b/containers/LoginForm/reducer.js
@@ -68,7 +68,8 @@ export const login = (state = defaultLoginState, action) => {
                     let err = action.error.type.split('.');
                     let type = err[err.length - 1];
 
-                    return loginSteps[type] ? updateLoginStep(state, type) : state.set('formError', action.error.message);
+                    return loginSteps[type] ? updateLoginStep(state, type) : state.set('formError', action.error.message)
+                    .setIn(['loginForm', 'inputs', 'username', 'disabled'], false);
                 } else if (action.result) {
                     return state.set('authenticated', true)
                                 .set('cookieChecked', true)

--- a/containers/LoginForm/reducer.js
+++ b/containers/LoginForm/reducer.js
@@ -56,6 +56,9 @@ export const login = (state = defaultLoginState, action) => {
     let validationResult;
     switch (action.type) {
         case LOGOUT:
+            if (action.methodRequestState === 'finished') {
+                return state.set('authenticated', false);
+            }
             return state;
         case LOGIN:
             if (action.methodRequestState === 'finished') {

--- a/containers/LoginForm/reducer.js
+++ b/containers/LoginForm/reducer.js
@@ -57,7 +57,7 @@ export const login = (state = defaultLoginState, action) => {
     switch (action.type) {
         case LOGOUT:
             if (action.methodRequestState === 'finished') {
-                return state.set('authenticated', false);
+                return defaultLoginState;
             }
             return state;
         case LOGIN:


### PR DESCRIPTION
The username input should not be enabled when the password is wrong. Are you sure that the check if(!nextProps.authenticated) in Gate component won't cause recursion at some point?