### PR TITLE
Extended accordion to support multiple arrow directions

### DIFF
--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -7,7 +7,8 @@ const Accordion = React.createClass({
         title: PropTypes.node,
         collapsed: PropTypes.bool,
         className: PropTypes.string,
-        fullWidth: PropTypes.bool
+        fullWidth: PropTypes.bool,
+        arrowDirection: PropTypes.object
     },
     getInitialState: function() {
         return { collapsed: this.props.collapsed || false };
@@ -17,7 +18,7 @@ const Accordion = React.createClass({
     },
     render() {
         return (
-          <Box title={this.props.title} showAccordeon {...this.props} collapsed={this.state.collapsed} onToggle={this.handleToggle}>
+          <Box title={this.props.title} arrowDirection={this.props.arrowDirection} showAccordeon {...this.props} collapsed={this.state.collapsed} onToggle={this.handleToggle}>
             {this.props.children}
           </Box>
         );

--- a/components/Box/index.js
+++ b/components/Box/index.js
@@ -4,7 +4,7 @@ import Glyphicon from '../Glyphicon';
 import style from './style.css';
 import classnames from 'classnames';
 
-const Box = ({children, className, title, externalTitleClasses, externalBodyClasses, titleType, showClose, fullWidth, minHeight, transparent, marginBottom = true, onClose, showAccordeon = false, collapsed = false, onToggle, ...props}) => {
+const Box = ({ children, className, title, externalTitleClasses, externalBodyClasses, titleType, showClose, fullWidth, minHeight, transparent, marginBottom = true, onClose, showAccordeon = false, collapsed = false, onToggle, arrowDirection, ...props }) => {
     let titleTypeClass;
     switch (titleType) {
         case 'small':
@@ -13,25 +13,34 @@ const Box = ({children, className, title, externalTitleClasses, externalBodyClas
         default:
             titleTypeClass = classnames('f20', 'f-semibold', 'padding-all-20');
     }
-    let accordeonDirection = collapsed ? 'arrowDown' : 'arrowUp';
-    let accordeon = showAccordeon ? <div className='pull-xs-right clearfix'><Glyphicon glyphicon={accordeonDirection} style={{color: '#B1B5B6'}} /></div> : null;
+
+    if (!arrowDirection) {
+        arrowDirection = {
+            collapsed: 'arrowDown',
+            expanded: 'arrowUp'
+        }
+    }
+
+    let accordeonDirection = collapsed ? arrowDirection.collapsed : arrowDirection.expanded;
+
+    let accordeon = showAccordeon ? <div className='pull-xs-right clearfix'><Glyphicon glyphicon={accordeonDirection} style={{ color: '#B1B5B6' }} /></div> : null;
     let fullWidthClass = fullWidth ? style.boxFull : style.boxInnerPadding;
     let transparentClass = transparent ? style.boxTransparent : null;
     let marginBottomClass = marginBottom ? null : style.boxMarginBottom;
     let classes = classnames(style.box, transparentClass, marginBottomClass, className);
-    let closeSection = showClose ? <span className={classnames(style.boxTitleClose, 'pointer')} onClick={onClose}><Button button='close' style={{float: 'left'}} /></span> : null;
+    let closeSection = showClose ? <span className={classnames(style.boxTitleClose, 'pointer')} onClick={onClose}><Button button='close' style={{ float: 'left' }} /></span> : null;
     let ballancerClass = showClose ? style.ballancer : null;
     let titleSectionClasses = classnames('f-upper', style.boxTitle, titleTypeClass, ballancerClass, externalTitleClasses);
     titleSectionClasses = showAccordeon ? classnames(titleSectionClasses, 'pointer') : titleSectionClasses;
     let rightSection = showAccordeon ? accordeon : closeSection;
     let titleSection = title ? <div className={titleSectionClasses} onClick={onToggle}>{title}{rightSection}</div> : null;
-    let minHeightStyle = minHeight ? {minHeight: minHeight} : null;
+    let minHeightStyle = minHeight ? { minHeight: minHeight } : null;
     let body = !collapsed ? <div className={classnames(fullWidthClass, externalBodyClasses)} style={minHeightStyle}>{children}</div> : null;
     return (
-      <div style={props.style} className={classes}>
-        {titleSection}
-        {body}
-      </div>
+        <div style={props.style} className={classes}>
+            {titleSection}
+            {body}
+        </div>
     );
 };
 


### PR DESCRIPTION
My current project requires the use of different glyph icons for collapse and expand.
The current implementation doesn't allow use of custom.