### PR TITLE
fix: UIS-1224: change Accordion's component state when new props are received

### DIFF
--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -16,6 +16,9 @@ const Accordion = React.createClass({
     handleToggle: function() {
         this.setState({ collapsed: !this.state.collapsed });
     },
+    componentWillReceiveProps: function(nextProps) {
+        this.setState({ collapsed: nextProps.collapsed });
+    },
     render() {
         return (
           <Box title={this.props.title} arrowDirection={this.props.arrowDirection} showAccordeon {...this.props} collapsed={this.state.collapsed} onToggle={this.handleToggle}>

--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -17,7 +17,9 @@ const Accordion = React.createClass({
         this.setState({ collapsed: !this.state.collapsed });
     },
     componentWillReceiveProps: function(nextProps) {
-        this.setState({ collapsed: nextProps.collapsed });
+        if (this.state.collapsed !== nextProps.collapsed) {
+            this.setState({ collapsed: nextProps.collapsed });
+        }
     },
     render() {
         return (


### PR DESCRIPTION
This fixes an issue with maker/checker compare grid sections not being open in some cases.