### PR TITLE
fix: UIS-2920: add support for case-insensitive unique validation

### DIFF
--- a/components/Input/validators/input.js
+++ b/components/Input/validators/input.js
@@ -14,6 +14,7 @@ export default (valueToValidate, validators) => {
         if (validator.type === textValidations.decimalOnly) isDecimalOnlyRule(valueToValidate, validator.precision, validator.scale, validator, result);
         if (validator.type === textValidations.email) isValidEmailRule(valueToValidate, validator, result);
         if (validator.type === textValidations.uniqueValue) isUniqueValueRule(valueToValidate, validator.values, validator, result);
+        if (validator.type === textValidations.uniqueValueCaseInsensitive) isUniqueValueRule(valueToValidate.toLowerCase(), validator.values, validator, result);
     });
 
     return result;

--- a/containers/TabContainer/validator.js
+++ b/containers/TabContainer/validator.js
@@ -63,6 +63,9 @@ export const validateTab = (sourceMap, validations, tabIndex, result, errors) =>
                     if (validation.type === validationTypes.text && rule.type === textValidations.uniqueValue) {
                         isUniqueValueRule(currentValue, rule.values, rule, result);
                     }
+                    if (validation.type === validationTypes.text && rule.type === textValidations.uniqueValueCaseInsensitive) {
+                        isUniqueValueRule(currentValue.toLowerCase(), rule.values, rule, result);
+                    }
                     if (validation.type === validationTypes.array && rule.type === arrayValidations.isRequired) {
                         isRequiredArrayRule(currentValue, rule, result);
                     }

--- a/validator/constants.js
+++ b/validator/constants.js
@@ -23,6 +23,7 @@ export const textValidations = {
     integerRange: 'integerRange', // minVal?, maxVal?
     decimalOnly: 'decimalOnly', // precision, scale
     uniqueValue: 'uniqueValue',
+    uniqueValueCaseInsensitive: 'uniqueValueCaseInsensitive',
     length: 'length', // minVal, maxVal
     regex: 'regex'  // value
 };


### PR DESCRIPTION
This is needed for Products - when creating (or editing) a Product, its name should not be equal to the name of an already existing Product (case-insensitive).
e.g.: I have a product named Test, and if i want to create another product named Test or test a validation error should be thrown.