### PR TITLE
Fixed a bug where every third press on a TabContainer's action button would always pass validations

### DIFF
--- a/containers/TabContainer/validator.js
+++ b/containers/TabContainer/validator.js
@@ -41,7 +41,9 @@ export const validateTab = (sourceMap, validations, tabIndex, result, errors) =>
                     currentValue = sourceMap.getIn(validation.key);
                 }
                 validation.rules.forEach((rule) => {
-                    rule.key = validation.key;
+                    rule.key = Array.isArray(validation.key)
+                        ? Array.from(validation.key) // new reference
+                        : validation.key;
                     if (validation.type === validationTypes.text && rule.type === textValidations.isRequired) {
                         isRequiredRule(currentValue, rule, result);
                     }


### PR DESCRIPTION
This fixes a bug in ```TabContainer``` where when you click on an action button three times it will successfully go through the frontend validations and execute the action. It happened on every sequential third press and only if no changes occurred between presses (no fields were touched).
The problem was that the same reference was used for an array which was later mutated using ```.pop()``` in one place while being used for validations in another.