### PR TITLE
fix(UA-78): Money values should be formatted

### DIFF
--- a/components/Input/MoneyInput.js
+++ b/components/Input/MoneyInput.js
@@ -1,0 +1,8 @@
+import React, { PropTypes } from 'react';
+import { moneyInputOptions } from '../../constants';
+import Input from './index';
+
+export default function MoneyInput(props) {
+    // The options prop will tell Input to use a Cleave.js input instead of <input> tag
+    return <Input options={props.options || moneyInputOptions} {...props} />;
+};

--- a/constants.js
+++ b/constants.js
@@ -5,3 +5,9 @@ export const methodRequestState = {
 
 export const documentPrefix = '/s/ut-document/repository/';
 export const documentTmpUploadPrefix = '/file-upload/';
+
+export const moneyInputOptions = {
+    numeral: true,
+    delimeter: ',',
+    numeralThousandsGroupStyle: 'thousand'
+};

--- a/helpers.js
+++ b/helpers.js
@@ -150,3 +150,25 @@ export const calculateAspectRatio = (file, scaleDimensions) => {
         };
     }
 };
+
+/* Formats a number replacing all matches of the regex with the delimeter
+    @param number/string value
+    @param string delimeter
+    @param regex regex
+    @returns string the formatted number as string
+*/
+export function formatMoney(value, delimeter = ',', regex = /\B(?=(\d{3})+$)/g) {
+    const stringValue = value.toString();
+
+    if (stringValue.includes('.')) {
+        // 10000.0456 => 10,000.0456
+        const parts = stringValue.toString().split('.');
+        const partInteger = parts[0];
+        const partDecimal = parts[1];
+        const formattedInteger = partInteger.replace(regex, delimeter);
+        return `${formattedInteger}.${partDecimal}`;
+    } else {
+        // 10000 => 10,000
+        return stringValue.replace(regex, delimeter);
+    }
+}


### PR DESCRIPTION
Added input value lifecycle methods to Input - format, parse (opposite of format) and normalize.
Input component can now use Cleave.js input to format the value.
Passing Input the "options" prop will make it use Cleave's input.
Added exported settings for a Cleave.js money field.
Added MoneyInput - a wrapper over TextField that provides the Cleave settings for a money field.
Added exported function for formatting money values that are not in inputs.

Closes UA-78