### PR TITLE
fix(ABTN-3836) : [ABZ] System Alerts: Uncaught TypeError: Cannot read property 'styleContentWrapper' of undefined

### DIFF
--- a/containers/TabContainer/index.js
+++ b/containers/TabContainer/index.js
@@ -237,9 +237,9 @@ class TabContainer extends Component {
                           />
                       </div>}
                   >
-                      <div className={style.contentComponentWrapper} style={activeTab.styleContentWrapper}>
+                      {activeTab && <div className={style.contentComponentWrapper} style={activeTab.styleContentWrapper}>
                           {activeTab.component}
-                      </div>
+                      </div>}
                   </Vertical>
                 </Vertical>
             </div>


### PR DESCRIPTION


- Add check in tab container to render activeTab content only in case
activeTab is not undefined

Closes ABTN-3836