### PR TITLE
fix (CEM-1922): PAP / Document Management: Details for the deleted document is shown twice in the Validation screen

### DIFF
--- a/components/Documents/helpers.js
+++ b/components/Documents/helpers.js
@@ -57,6 +57,20 @@ export function mergeDocumentsWithChanged(documents, changedDocuments) {
     changedDocuments.forEach((changedDoc) => {
         switch (changedDoc.statusId) {
             case 'deleted':
+                for (let i = 0; i < documents.length; i++) {
+                    if (documents[i].documentId) {
+                        if (documents[i].documentId === changedDoc.documentId) {
+                            documents.splice(i, 1);
+                            break;
+                        }
+                    } else if (documents[i].documentUnapprovedId) {
+                        if (documents[i].documentUnapprovedId === changedDoc.documentUnapprovedId) {
+                            documents.splice(i, 1);
+                            break;
+                        }
+                    }
+                }
+                break;
             case 'replaced':
             case 'pending':
             case 'archived':


### PR DESCRIPTION
- in case of delete, remove the document from documents array,
if it is changed

Closes CEM-1922