### PR TITLE
fix(CEM-2912): [PAP][Add Document]

### DIFF
--- a/components/DocumentUpload/Camera.js
+++ b/components/DocumentUpload/Camera.js
@@ -43,7 +43,11 @@ export default class Camera extends Component {
 
     onVideoSupported(stream) {
         this.stream = stream;
-        this.refs.video.src = window.URL.createObjectURL(stream);
+        try {
+            this.refs.video.srcObject = stream;
+        } catch (error) {
+            this.refs.video.src = window.URL.createObjectURL(stream);
+        }
     }
 
     onVideoNotSupported(error) {


### PR DESCRIPTION
Image cannot be taken with the camera.

- window.URL.createObjectURL is depricated,
so set srcObject to the MediaStream directly