### PR TITLE
fix: confirm and status dialogs are not showing

### DIFF
--- a/components/ConfirmDialog/index.js
+++ b/components/ConfirmDialog/index.js
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 import Button from '@material-ui/core/Button';
 
 export default class DialogExampleModal extends Component {
@@ -38,16 +42,26 @@ export default class DialogExampleModal extends Component {
     }
 
     render() {
-        const actions = [];
-        if (!this.props.cannotSubmit) {
-            actions.push(<Button label={this.props.submitLabel || 'Yes'} disabled={this.props.cannotSubmit} onClick={this.submit} />);
-        }
-        actions.push(<Button label={this.props.cancelLabel || 'No'} primary onClick={this.close} />);
-
         return (
             <div>
-                <Dialog title={this.props.title} actions={actions} modal open={this.state.open}>
-                    {this.state.message}
+                <Dialog
+                  fullWidth={true}
+                  open={this.state.open} 
+                  aria-labelledby="alert-dialog-title"
+                  aria-describedby="alert-dialog-description"
+                >
+                  <DialogTitle id="alert-dialog-title">{this.props.title}</DialogTitle>
+                  <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                      {this.props.message}
+                    </DialogContentText>
+                  </DialogContent>
+                  <DialogActions>
+                    {!this.props.cannotSubmit && <Button disabled={this.props.cannotSubmit} onClick={this.submit}>{this.props.submitLabel || 'Yes'}</Button>}
+                    <Button color="primary" onClick={this.close}>
+                      {this.props.cancelLabel || 'No'}
+                    </Button>
+                  </DialogActions>
                 </Dialog>
             </div>
         );

--- a/components/ConfirmDialog/index.js
+++ b/components/ConfirmDialog/index.js
@@ -45,23 +45,23 @@ export default class DialogExampleModal extends Component {
         return (
             <div>
                 <Dialog
-                  fullWidth={true}
-                  open={this.state.open} 
-                  aria-labelledby="alert-dialog-title"
-                  aria-describedby="alert-dialog-description"
+                    fullWidth
+                    open={this.state.open}
+                    aria-labelledby='alert-dialog-title'
+                    aria-describedby='alert-dialog-description'
                 >
-                  <DialogTitle id="alert-dialog-title">{this.props.title}</DialogTitle>
-                  <DialogContent>
-                    <DialogContentText id="alert-dialog-description">
-                      {this.props.message}
-                    </DialogContentText>
-                  </DialogContent>
-                  <DialogActions>
-                    {!this.props.cannotSubmit && <Button disabled={this.props.cannotSubmit} onClick={this.submit}>{this.props.submitLabel || 'Yes'}</Button>}
-                    <Button color="primary" onClick={this.close}>
-                      {this.props.cancelLabel || 'No'}
-                    </Button>
-                  </DialogActions>
+                    <DialogTitle id='alert-dialog-title'>{this.props.title}</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText id='alert-dialog-description'>
+                            {this.props.message}
+                        </DialogContentText>
+                    </DialogContent>
+                    <DialogActions>
+                        {!this.props.cannotSubmit && <Button disabled={this.props.cannotSubmit} onClick={this.submit}>{this.props.submitLabel || 'Yes'}</Button>}
+                        <Button color='primary' onClick={this.close}>
+                            {this.props.cancelLabel || 'No'}
+                        </Button>
+                    </DialogActions>
                 </Dialog>
             </div>
         );

--- a/components/StatusDialog/index.js
+++ b/components/StatusDialog/index.js
@@ -1,16 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
 import Button from '@material-ui/core/Button';
 
 const StatusDialog = ({ status, onClose }) => {
-    const actions = [];
-
     const isOpen = status.size > 0;
     const statusString = status.get('status');
-    if (statusString !== 'pending') {
-        actions.push(<Button label='Ok' onClick={onClose} />);
-    }
 
     const upperCasedStatus = statusString ? statusString.toUpperCase() : '';
     const message = status.get('message');
@@ -24,15 +22,26 @@ const StatusDialog = ({ status, onClose }) => {
 
     return (
         <div>
-            <Dialog actions={actions} modal open={isOpen}>
-                <div dangerouslySetInnerHTML={{__html: displayMsg.join(' - ')}} />
+            <Dialog
+              fullWidth={true}
+              open={isOpen}
+              aria-describedby="alert-dialog-description"
+            >
+              <DialogContent>
+                <DialogContentText id="alert-dialog-description">
+                  <div dangerouslySetInnerHTML={{__html: displayMsg.join(' - ')}} />
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                {statusString !== 'pending' && <Button onClick={onClose}>{'Ok'}</Button>}
+              </DialogActions>  
             </Dialog>
         </div>
     );
 };
 
 StatusDialog.propTypes = {
-    status: PropTypes.object.isRequired, // immutalbe object,
+    status: PropTypes.object.isRequired, // immutable object,
     onClose: PropTypes.func.isRequired
 };
 

--- a/components/StatusDialog/index.js
+++ b/components/StatusDialog/index.js
@@ -23,18 +23,18 @@ const StatusDialog = ({ status, onClose }) => {
     return (
         <div>
             <Dialog
-              fullWidth={true}
-              open={isOpen}
-              aria-describedby="alert-dialog-description"
+                fullWidth
+                open={isOpen}
+                aria-describedby='alert-dialog-description'
             >
-              <DialogContent>
-                <DialogContentText id="alert-dialog-description">
-                  <div dangerouslySetInnerHTML={{__html: displayMsg.join(' - ')}} />
-                </DialogContentText>
-              </DialogContent>
-              <DialogActions>
-                {statusString !== 'pending' && <Button onClick={onClose}>{'Ok'}</Button>}
-              </DialogActions>  
+                <DialogContent>
+                    <DialogContentText id='alert-dialog-description'>
+                        <div dangerouslySetInnerHTML={{__html: displayMsg.join(' - ')}} />
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    {statusString !== 'pending' && <Button onClick={onClose}>Ok</Button>}
+                </DialogActions>
             </Dialog>
         </div>
     );

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@storybook/react": "5.3.19",
     "bootstrap": "^4.3.1",
     "tap": "^12.7.0",
-    "ut-tools": "^6.30.5"
+    "ut-tools": "^6.33.6"
   },
   "peerDependencies": {
     "@date-io/date-fns": "^1.3.13",


### PR DESCRIPTION
Fixing the following issues:

![image](https://user-images.githubusercontent.com/36701256/89637049-49134780-d8b2-11ea-9f04-f689c76bb244.png)

![image](https://user-images.githubusercontent.com/36701256/89637287-9d1e2c00-d8b2-11ea-9e42-be2c26cf301c.png)

![image](https://user-images.githubusercontent.com/36701256/89637368-ba52fa80-d8b2-11ea-9406-e0ae087a9ebf.png)

As a legacy we are using the material-ui components directly and on other hand for other dialogs we have custom implementation. This merge requests represents a fix where the behavior is the same as it has been previously. 