### PR TITLE
fix: render "null" in case of no children

### DIFF
--- a/components/Text/index.js
+++ b/components/Text/index.js
@@ -15,7 +15,7 @@ export default class Text extends React.Component {
 
     render() {
         let {children, params, prefix} = this.props;
-        if (typeof children !== 'string') return children;
+        if (typeof children !== 'string') return children || null;
         let template = children;
         if (typeof this.context.translate === 'function') {
             const text = (prefix ? [prefix, children] : [children]).join('>');


### PR DESCRIPTION
Business units and Users Edit screens open ConfirmationModal without message.

ConfirmationModal renders <Text>{message}</Text> leading React error for not allowing undefine to be rendered.