### PR TITLE
fix: help menu link should not change users page

### DIFF
--- a/components/Tab/Tab.js
+++ b/components/Tab/Tab.js
@@ -35,7 +35,16 @@ export default class Tab extends Component {
         const { tab, disabled, className } = this.props;
 
         if (!tab.routeName) {
-            tab.routeName = 'ut-user:home';
+            return (
+                <span
+                    style={this.props.style}
+                    className={!disabled ? classNames(className, styles.navigationTab) : classNames(styles.navigationTab, styles.navigationTabDisabled)}
+                    activeClassName={styles.navigationTabActive}
+                    onClick={this.onTabClick}
+                >
+                    <Text>{tab.title}</Text>
+                </span>
+            );
         }
 
         return (

--- a/components/Tab/styles.css
+++ b/components/Tab/styles.css
@@ -1,7 +1,7 @@
 @import './default-config.css';
 @import 'config.css';
 
-a.navigationTab {
+a.navigationTab, span.navigationTab {
   display: flex;
   justify-content: space-between;
   color: var(--ut-front-react-standardMainNavigationTextColor);
@@ -11,11 +11,11 @@ a.navigationTab {
   white-space: nowrap;
 }
 
-a.navigationTab.menuItemTab {
+a.navigationTab.menuItemTab, span.navigationTab.menuItemTab {
   color: var(--ut-front-react-standardTabMenuTextColor);
 }
 
-a.navigationTab.menuItemTab:hover {
+a.navigationTab.menuItemTab:hover, span.navigationTab.menuItemTab:hover {
   color: var(--ut-front-react-standardMainNavigationTextHoverColor);
 }
 
@@ -26,18 +26,18 @@ a.navigationTab.menuItemTab:hover {
   outline: 0;
 }
 
-a.navigationTab.navigationTabDisabled {
+a.navigationTab.navigationTabDisabled, span.navigationTab.navigationTabDisabled {
   color: #e6e6e6;
   cursor: not-allowed;;
 }
 
-a.navigationTabActive {
+a.navigationTabActive, span.navigationTabActive {
 }
 
-a.navigationTabActive:hover {
+a.navigationTabActive:hover, span.navigationTabActive:hover {
   color: var(--ut-front-react-standardMainNavigationTextHoverColor);
 }
-a.navigationTabActive:focus {
+a.navigationTabActive:focus, span.navigationTabActive:focus {
   color: var(--ut-front-react-standardMainNavigationTextColor);
   text-decoration: none;
 }


### PR DESCRIPTION
Used in: 
https://github.com/softwaregroup-bg/ut-front-react/blob/master/components/HeaderNew/HeaderProfileInfo.js#L50-L54

Previous behaviour:
![image](https://user-images.githubusercontent.com/7376399/108060390-7a3db300-705f-11eb-865a-499b723edc46.png)

How it currently looks:
![image](https://user-images.githubusercontent.com/7376399/108060236-45316080-705f-11eb-94f7-5ffde7283b7b.png)

![image](https://user-images.githubusercontent.com/7376399/108060467-92adcd80-705f-11eb-9051-c931b250ec46.png)

