### PR TITLE
fix: Page Headings displayed cut in half

### DIFF
--- a/components/MaterialUILayout/index.js
+++ b/components/MaterialUILayout/index.js
@@ -6,6 +6,15 @@ import DateUtils from '../DateUtils';
 const theme = createMuiTheme({
     palette: {
         type: 'light'
+    },
+    overrides: {
+        MuiCssBaseline: {
+            '@global': {
+                body: {
+                    lineHeight: 1.1
+                }
+            }
+        }
     }
 });
 

--- a/components/PageLayout/style.css
+++ b/components/PageLayout/style.css
@@ -51,10 +51,12 @@
 }
 
 .heading {
+    font-size: 26px;
+    font-weight: normal;
     margin: 0;
     text-overflow: ellipsis;
     overflow: hidden;
-    white-space: nowrap;     
+    white-space: nowrap;
 }
 
 .headingTextWrap {
@@ -62,7 +64,7 @@
     white-space: nowrap;
     vertical-align: middle;
     display: inline-block;
-} 
+}
 
 .h100pr {
     height: 100%;


### PR DESCRIPTION
От миграцията към нов material-ui насам, всички заглавия бяха разполовени и цялостно съдържанието на порталите бе станало по-разкрачено.
Разгледах какво е имало "някога" и слагам 2 промени, за да стане "както беше".

**Преди корекцията:**
![image](https://user-images.githubusercontent.com/5932031/113098281-f56abb00-9200-11eb-9664-79eca00873db.png)

**След корекцията:**
![image](https://user-images.githubusercontent.com/5932031/113098309-fe5b8c80-9200-11eb-9a47-88212c695f86.png)
