### PR TITLE
fix vertical scrolling on agent onboarding

### DIFF
--- a/components/Layout/verticalStyles.css
+++ b/components/Layout/verticalStyles.css
@@ -4,13 +4,13 @@
 }
 
 .vertical {
-    overflow: hidden;
+    // overflow: hidden;
     width: 100%;
 }
 
 .innerContent {
     height: 100%;
-    overflow: hidden;
+    //overflow: hidden;
     display: flex;
     flex-direction: column;
 }

--- a/components/Layout/verticalStyles.css
+++ b/components/Layout/verticalStyles.css
@@ -4,13 +4,11 @@
 }
 
 .vertical {
-    // overflow: hidden;
     width: 100%;
 }
 
 .innerContent {
     height: 100%;
-    //overflow: hidden;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
Fix vertical scrolling on NMB during agent onboarding. On small screens, navigation buttons for next/previous are not visible
as in the image below. notice the absence of scroll bars

![image](https://user-images.githubusercontent.com/87642721/129024034-50cdf943-d4cb-408a-a7f0-4cdc7a68e790.png)


The expexted behaviour that this PR introduces is as follows where it is possible to scroll to the navigation footer

![image](https://user-images.githubusercontent.com/87642721/129024217-c000677f-f510-4015-b281-e85eb28230ea.png)

