### PR TITLE
fix (PSTB-4685): improve misaligned and underlined tabs

### DIFF
--- a/components/TabMenu/style.css
+++ b/components/TabMenu/style.css
@@ -47,6 +47,7 @@
     border-bottom: 1px solid #D7D6D6;
     cursor: pointer;
     color: #373a3c;
+    text-decoration: none;
     width: 100%;
     height: 100%;
 }
@@ -68,6 +69,7 @@ a.tabMenuWrap:hover.tabMenuWrapSelected,
     color: var(--ut-front-react-standardTabMenuColor);
 }
 .tabMenuWrap .tabMenuItemContent {
+    line-height: 1.5;
     padding: 10px 29px 10px 10px;
 }
 .tabMenuWrapSelected {


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/5932031/136653490-e93c96b8-ab93-43f3-a59c-15b5de171f1c.png)

**After:**
![image](https://user-images.githubusercontent.com/5932031/136653493-556b97f8-79e5-4803-be57-1c6c1fc8bf5f.png)

FYI @behrindzhambaz / @BozhidarTodorov / @pavelGeorgievSG 