### PR TITLE
Add ability to add cutom styling to Grid Table cells

### DIFF
--- a/components/SimpleGrid/Body/Column.js
+++ b/components/SimpleGrid/Body/Column.js
@@ -35,16 +35,17 @@ export default class Column extends Component {
             fieldClasses.push(this.getStyle(this.props.field.inSpanStyle));
         }
 
-        const transformedValue = this.props.transformValue(value, this.props.field, this.props.data, false, this.props.recordIndex)
-        const fieldStyling = transformedValue?.style
-        const fieldValue = transformedValue?.value || transformedValue
+        const transformedValue = this.props.transformValue(value, this.props.field, this.props.data, false, this.props.recordIndex);
+        const fieldStyling = transformedValue?.style;
+        const fieldValue = transformedValue?.value || transformedValue;
 
         return (
             <td
                 onClick={this.handleClick(value)}
                 style={fieldStyling || this.props.field.style}
                 className={fieldClasses.join(' ')}
-                colSpan={this.props.colspan}>
+                colSpan={this.props.colspan}
+            >
                 {fieldValue}
             </td>
         );

--- a/components/SimpleGrid/Body/Column.js
+++ b/components/SimpleGrid/Body/Column.js
@@ -35,9 +35,17 @@ export default class Column extends Component {
             fieldClasses.push(this.getStyle(this.props.field.inSpanStyle));
         }
 
+        const transformedValue = this.props.transformValue(value, this.props.field, this.props.data, false, this.props.recordIndex)
+        const fieldStyling = transformedValue?.style
+        const fieldValue = transformedValue?.value || transformedValue
+
         return (
-            <td onClick={this.handleClick(value)} style={this.props.field.style} className={fieldClasses.join(' ')} colSpan={this.props.colspan}>
-                {this.props.transformValue(value, this.props.field, this.props.data, false, this.props.recordIndex)}
+            <td
+                onClick={this.handleClick(value)}
+                style={fieldStyling || this.props.field.style}
+                className={fieldClasses.join(' ')}
+                colSpan={this.props.colspan}>
+                {fieldValue}
             </td>
         );
     }


### PR DESCRIPTION
Using the `transformValue` is the `SimpleGrid` component , its possible to provide a value that is customised or to provide a value and custom styling for the Table Cell by havind the  ```transformValue``` function take the folowing signature

```
function transformValue(value, field, data, false, recordIndex) {
    .//... function logic
    return {
       value,
       style   // this is a valid jsx style object
   }
```

or the current

```
function transformValue(value, field, data, false, recordIndex) {
    .//... function logic
    return value
}
```