### PR TITLE
fix (ECNT-9999) : Add name of devtools extension

### DIFF
--- a/components/DocumentUpload/index.js
+++ b/components/DocumentUpload/index.js
@@ -288,7 +288,7 @@ export default class DocumentUpload extends Component {
 
     uploadFile = async(file, uploadURL = '/file-upload') => {
         const {
-            useFile,
+            useFile: attachFile,
             uploadDocument
         } = this.props;
         const data = new window.FormData();
@@ -308,7 +308,7 @@ export default class DocumentUpload extends Component {
             const reader = new window.FileReader();
             reader.onload = (data) => {
                 try {
-                    useFile({
+                    attachFile({
                         filename: attachmentResult.result.filename,
                         createdDate: new Date().toISOString(),
                         extension: ext,

--- a/components/DocumentUpload/index.js
+++ b/components/DocumentUpload/index.js
@@ -288,7 +288,7 @@ export default class DocumentUpload extends Component {
 
     uploadFile = async(file, uploadURL = '/file-upload') => {
         const {
-            useFile: attachFile,
+            useFile,
             uploadDocument
         } = this.props;
         const data = new window.FormData();
@@ -308,7 +308,8 @@ export default class DocumentUpload extends Component {
             const reader = new window.FileReader();
             reader.onload = (data) => {
                 try {
-                    attachFile({
+                    // eslint-disable-next-line react-hooks/rules-of-hooks
+                    useFile({
                         filename: attachmentResult.result.filename,
                         createdDate: new Date().toISOString(),
                         extension: ext,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@material-ui/lab": "^4.0.0-alpha.57",
     "bootstrap": "^4.3.1",
     "tap": "^15.0.9",
-    "ut-tools": "^6.33.6"
+    "ut-tools": "^6.40.0"
   },
   "peerDependencies": {
     "@date-io/date-fns": "^1.3.13",

--- a/ui/Store.js
+++ b/ui/Store.js
@@ -12,10 +12,10 @@ const resetStore = (reducer, resetAction) => {
         return reducer(state, action);
     };
 };
-
+const devToolsExtension = window.devToolsExtension || window.__REDUX_DEVTOOLS_EXTENSION__;
 const enhancer = compose(
-    ((typeof window !== 'undefined') && window.devToolsExtension)
-        ? window.devToolsExtension({
+    ((typeof window !== 'undefined') && devToolsExtension)
+        ? devToolsExtension({
             serialize: true,
             actionSanitizer: (action) => {
                 if (typeof action.type === 'symbol') {


### PR DESCRIPTION
- Handle new name  of the devtools extension - window.__REDUX_DEVTOOLS_EXTENSION__ (valid since verison 2.7 of the redux dev tools)