### PR TITLE
fix (AAA-000): loader animation not spinning

### DIFF
--- a/components/Loader/styles.css
+++ b/components/Loader/styles.css
@@ -45,7 +45,10 @@
     border-radius: 100%;
     border: 3px solid #4096fd;
     border-bottom-color: transparent;
-    animation: rotate 0.8s linear infinite;
+    animation-name: rotate;
+    animation-duration: 0.8s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
 }
 
 .message {


### PR DESCRIPTION
This has been driving me nuts for a long time - the **spinner loader animation was not working**.

Not sure what happened some time ago in css-loader or postcss or ut-weback, but the animation shorthand property was breaking the animation, causing the name of the animation to be localised.

With this fix, the animation works.

FYI @NKozhuharski @BozhidarTodorov @pavelGeorgievSG 