### PR TITLE
feat:UTM-134 PAP - User Management - adding document via camera is no…

### DIFF
--- a/components/DocumentUpload/Camera.js
+++ b/components/DocumentUpload/Camera.js
@@ -42,7 +42,7 @@ export default class Camera extends Component {
 
     onVideoSupported(stream) {
         this.stream = stream;
-        this.refs.video.src = window.URL.createObjectURL(stream);
+        this.refs.video.srcObject = stream;
     }
 
     onVideoNotSupported(error) {


### PR DESCRIPTION
The "src" property is deprecated in favour of "srcObject". That's why the camera is not working.
More info here: [https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject](url) 