### PR TITLE
fix(MSA-2836): Different font size and different left spacing between Text Fields and Date Pickers

### DIFF
--- a/components/DatePicker/style.css
+++ b/components/DatePicker/style.css
@@ -116,7 +116,8 @@
 
 .datePicker input {
     padding-right: 32px !important;
-    padding-left: 5px !important;
+    padding-left: 10px !important;
+    font-size: 14px;
 }
 
 .datePicker hr {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85224545/185126192-a3d6c04c-f4ca-4103-8d1a-332494ac09fe.png)
