### PR TITLE
fix(msa-2966): Changed vertical view to not be shown above 1023 px width

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -483,7 +483,7 @@ ui.nav.nav-tabs li.nav-item.nav-tab {
     cursor: pointer;
 }*/
 
-@media only screen and (min-device-width: 280px) and (max-device-width:  1365px) {
+@media only screen and (min-device-width: 280px) and (max-device-width:  1023px) {
     .tableWrap table, thead,  th, td, tr {
         display: block;
     }


### PR DESCRIPTION
Solves jira ticket MSA-2966.
When a user enters the portal when their laptop display size is scaled to 150% or 175% a vertical view is shown. This fixes that. The only problem was that the table would extend beyond the screen width which is fixed in a separate PR in the `ut-customer` repo.