### PR TITLE
feat: added version number component on Login page

### DIFF
--- a/components/LoginPage/index.js
+++ b/components/LoginPage/index.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import LoginForm from '../../containers/LoginForm';
+import VersionNumber from '../../containers/VersionNumber';
 import { getClass } from '../../utils/helpers';
 import styles from './styles.css';
 
@@ -11,6 +12,7 @@ class LoginPage extends Component {
             <div className={styles.loginContainer}>
                 <div className={classnames(this.context.implementationStyle.loginLogoHeader, getClass(styles, 'loginLogo loginPageHeader'))} />
                 <LoginForm routerParams={this.props.match && this.props.match.params} history={this.props.history} />
+                <div className={getClass(styles, 'loginVersion')}><VersionNumber /></div>
                 <div className={classnames(this.context.implementationStyle.loginLogoFooter, getClass(styles, 'loginLogo loginPageFooter'))} />
             </div>
         );

--- a/components/LoginPage/styles.css
+++ b/components/LoginPage/styles.css
@@ -21,6 +21,12 @@
     background: inline('./images/topLogo.png') no-repeat center;
 }
 
+.loginVersion {
+    width: 100%;
+    display: block;
+    margin-top: 15px;
+}
+
 .loginPageFooter {
     margin-top: 55px;
     background: inline('./images/bottomLogo.png') no-repeat center;

--- a/containers/LoginForm/actions.js
+++ b/containers/LoginForm/actions.js
@@ -40,7 +40,11 @@ export const cookieCheck = (params) => ({
     type: COOKIE_CHECK,
     method: 'identity.check',
     suppressErrorWindow: true,
-    params: Object.assign({channel: 'web'}, (params || {}))
+    params: {
+        channel: 'web',
+        ...params,
+        $http: {...params.$http, returnResponseHeaders: true }
+    }
 });
 
 export const validateForm = () => ({
@@ -51,7 +55,7 @@ export const logout = (params) => ({
     type: LOGOUT,
     method: 'identity.closeSession',
     suppressErrorWindow: true,
-    params: {}
+    params: {$http: {...params?.$http, returnResponseHeaders: true }}
 });
 
 export const clearLoginState = () => {

--- a/containers/LoginForm/reducer.js
+++ b/containers/LoginForm/reducer.js
@@ -49,7 +49,8 @@ const defaultLoginState = Immutable.fromJS({
     loginType: '',
     formError: '',
     shouldSubmit: false,
-    loginData: {}
+    loginData: {},
+    version: ''
 });
 
 const loginReducer = (state = defaultLoginState, action) => {
@@ -60,7 +61,8 @@ const loginReducer = (state = defaultLoginState, action) => {
             if (action.methodRequestState === 'finished') {
                 return state
                     .set('logoutRedirectUrl', action.result?.logoutRedirectUrl || logoutRedirectUrl)
-                    .set('isLogout', true);
+                    .set('isLogout', true)
+                    .set('version', action.result?.responseHeaders['x-ut-version']);
             }
             return defaultLoginState
                 .set('isLogout', true);
@@ -119,7 +121,8 @@ const loginReducer = (state = defaultLoginState, action) => {
                 if (action.error) {
                     return state.delete('result')
                         .set('cookieChecked', true)
-                        .set('authenticated', false);
+                        .set('authenticated', false)
+                        .set('version', action.error?.responseHeaders['x-ut-version']);
                 } else if (action.result) {
                     logoutRedirectUrl = action.result.logoutRedirectUrl;
                     return state.set('result', Immutable.fromJS(action.result))

--- a/containers/VersionNumber/default-config.css
+++ b/containers/VersionNumber/default-config.css
@@ -1,0 +1,4 @@
+:root {
+    --ut-front-react-loginVersionColor: #949494;
+    --ut-front-react-loginVersionSize: 12px;
+}

--- a/containers/VersionNumber/index.js
+++ b/containers/VersionNumber/index.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import styles from './styles.css';
+
+class VersionNumber extends Component {
+    render() {
+        const { version } = this.props;
+
+        if (version) {
+            return (
+                <div className={styles.wrap}>
+                    Version: {version}
+                </div>
+            );
+        }
+        return <div />;
+    }
+}
+
+export default connect(
+    ({ login }) => {
+        return {
+            version: login.get('version')
+        };
+    },
+    { }
+)(VersionNumber);
+
+VersionNumber.propTypes = {
+    version: PropTypes.string
+};

--- a/containers/VersionNumber/styles.css
+++ b/containers/VersionNumber/styles.css
@@ -1,0 +1,10 @@
+@import './default-config.css';
+@import 'config.css';
+
+.wrap {
+    width: 100%;
+    display: block;
+    color: var(--ut-front-react-loginVersionColor);
+    text-align: center;
+    font-size: var(--ut-front-react-loginVersionSize);
+}


### PR DESCRIPTION
This PR introduces a new version number component on the login page, displayed after the credentials box. The version number is dynamically fetched from the `x-ut-version` header, which is returned in the cookie check and logout requests. This allows users and developers to easily identify the current version of the application.

- Added a version number component to the login page UI
- The version is retrieved via the `x-ut-version` header on relevant API calls
- Display occurs after the credentials input box

Prerequisites
Version of ut-port-jsonrpc including [this](https://github.com/softwaregroup-bg/ut-port-jsonrpc/pull/33) pull request.

![image](https://github.com/user-attachments/assets/ef052ca1-16c9-4d0f-9f56-96c3c668bda2)
